### PR TITLE
[ Feature ] Frontend Localization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,22 @@
 {
   "name": "webp-png-converter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "webp-png-converter",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",
         "@electron-toolkit/utils": "^3.0.0",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mui/material": "^6.1.3",
+        "i18next": "^23.16.0",
+        "react-i18next": "^15.0.3",
         "sharp": "^0.33.5"
       },
       "devDependencies": {
@@ -5767,6 +5770,14 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -5809,6 +5820,28 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "23.16.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.0.tgz",
+      "integrity": "sha512-Ni3CG6c14teOogY19YNRl+kYaE/Rb59khy0VyHVn4uOZ97E2E/Yziyi6r3C3s9+wacjdLZiq/LLYyx+Cgd+FCw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-corefoundation": {
@@ -7392,6 +7425,27 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.0.3.tgz",
+      "integrity": "sha512-BlO1P+oLKjjIxDBQ0GkAIMacgjfMbnvops+3Y5nZXF7UJ99v4KCWr0Na1azJXC8AMiNWp4kgUcFCJM7U9ZsUDg==",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -8659,6 +8713,14 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@emotion/styled": "^11.13.0",
         "@mui/material": "^6.1.3",
         "i18next": "^23.16.0",
+        "i18next-browser-languagedetector": "^8.0.0",
         "react-i18next": "^15.0.3",
         "sharp": "^0.33.5"
       },
@@ -5840,6 +5841,14 @@
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
         }
       ],
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.0.0.tgz",
+      "integrity": "sha512-zhXdJXTTCoG39QsrOCiOabnWj2jecouOqbchu3EfhtSHxIB5Uugnm9JaizenOy39h7ne3+fLikIjeW88+rgszw==",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@emotion/styled": "^11.13.0",
     "@mui/material": "^6.1.3",
     "i18next": "^23.16.0",
+    "i18next-browser-languagedetector": "^8.0.0",
     "react-i18next": "^15.0.3",
     "sharp": "^0.33.5"
   },

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "@electron-toolkit/eslint-config": "^1.0.2",
     "@electron-toolkit/eslint-config-prettier": "^2.0.0",
     "@vitejs/plugin-react": "^4.3.1",
-    "electron": "^31.0.2",
-    "electron-builder": "^24.13.3",
+    "electron": "^32.2.0",
+    "electron-builder": "^25.1.8",
     "electron-vite": "^2.3.0",
-    "eslint": "^8.57.0",
-    "eslint-plugin-react": "^7.34.3",
-    "prettier": "^3.3.2",
+    "eslint": "^9.12.0",
+    "eslint-plugin-react": "^7.37.1",
+    "prettier": "^3.3.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "vite": "^5.3.1"
+    "vite": "^5.4.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@mui/material": "^6.1.3",
+    "i18next": "^23.16.0",
+    "react-i18next": "^15.0.3",
     "sharp": "^0.33.5"
   },
   "devDependencies": {

--- a/src/renderer/Locales/en.json
+++ b/src/renderer/Locales/en.json
@@ -1,5 +1,9 @@
 {
-  "translation" : {
-
+  "Conversion" : {
+    "Delete-Original" : "Delete original file" ,
+    "Select-Folder" : "Select Folder" ,
+    "Select-Type" : "Select the conversion type" ,
+    "Folder-Path" : "Folder Path" ,
+    "Convert" : "Convert"
   }
 }

--- a/src/renderer/Locales/en.json
+++ b/src/renderer/Locales/en.json
@@ -1,9 +1,20 @@
 {
   "Conversion" : {
-    "Delete-Original" : "Delete original file" ,
-    "Select-Folder" : "Select Folder" ,
-    "Select-Type" : "Select the conversion type" ,
-    "Folder-Path" : "Folder Path" ,
+
+    "Folder" : {
+      "Placeholder" : "Please select a folder" ,
+      "Select" : "Folder Path" ,
+      "Label" : "Folder"
+    },
+
+    "Type" : {
+      "Heading" : "Select the conversion type"
+    },
+
+    "Cleanup" : {
+      "Heading" : "Delete original file"
+    },
+
     "Convert" : "Convert"
   }
 }

--- a/src/renderer/Locales/en.json
+++ b/src/renderer/Locales/en.json
@@ -1,0 +1,5 @@
+{
+  "translation" : {
+
+  }
+}

--- a/src/renderer/Locales/jp.json
+++ b/src/renderer/Locales/jp.json
@@ -1,0 +1,5 @@
+{
+  "translation" : {
+
+  }
+}

--- a/src/renderer/Locales/jp.json
+++ b/src/renderer/Locales/jp.json
@@ -1,9 +1,20 @@
 {
   "Conversion" : {
-    "Delete-Original" : "元のファイルを削除" ,
-    "Select-Folder" : "フォルダを選択" ,
-    "Select-Type" : "変換タイプを選択" ,
-    "Folder-Path" : "フォルダパス" ,
+
+    "Folder" : {
+      "Placeholder" : "フォルダが選択されていません" ,
+      "Select" : "フォルダを選択" ,
+      "Label" : "フォルダパス"
+    },
+
+    "Type" : {
+      "Heading" : "変換タイプを選択"
+    },
+
+    "Cleanup" : {
+      "Heading" : "元のファイルを削除"
+    },
+
     "Convert" : "変換"
   }
 }

--- a/src/renderer/Locales/jp.json
+++ b/src/renderer/Locales/jp.json
@@ -1,5 +1,9 @@
 {
-  "translation" : {
-
+  "Conversion" : {
+    "Delete-Original" : "元のファイルを削除" ,
+    "Select-Folder" : "フォルダを選択" ,
+    "Select-Type" : "変換タイプを選択" ,
+    "Folder-Path" : "フォルダパス" ,
+    "Convert" : "変換"
   }
 }

--- a/src/renderer/src/App.jsx
+++ b/src/renderer/src/App.jsx
@@ -54,15 +54,15 @@ const App = () => {
         </Typography>
 
         <Button variant="contained" color="primary" onClick={selectFolder} disabled={isLoading}>
-          { t('Select-Folder') }
+          { t('Folder.Select') }
         </Button>
 
         <Box my={2}>
           <TextField
             fullWidth
             variant="outlined"
-            label={ t('Folder-Path') }
-            value={folderPath ?? 'フォルダが選択されていません' }
+            label={ t('Folder.Label') }
+            value={folderPath ?? t('Folder.Placeholder') }
             aria-readonly = 'true'
             aria-disabled = 'true'
             disabled = { true }
@@ -72,7 +72,7 @@ const App = () => {
         <Box my={2}>
           <FormControl>
             <FormLabel component="legend">
-              { t('Select-Type') }
+              { t('Type.Heading') }
             </FormLabel>
             <RadioGroup
               row
@@ -89,7 +89,7 @@ const App = () => {
         <Box my={2}>
           <FormControl>
             <FormLabel component="legend" mt={4}>
-              { t('Delete-Original') }
+              { t('Cleanup.Heading') }
             </FormLabel>
             <RadioGroup
               row

--- a/src/renderer/src/App.jsx
+++ b/src/renderer/src/App.jsx
@@ -1,10 +1,14 @@
 import React, { useState } from 'react';
 import { Button, Typography, TextField, Box, Container, Alert, CircularProgress, Radio, RadioGroup, FormControlLabel, FormLabel, FormControl } from '@mui/material';
+import { useTranslation } from 'react-i18next'
 
 import './I18n'
 
 
 const App = () => {
+
+  const { t } = useTranslation('Conversion')
+
   const [folderPath, setFolderPath] = useState('');
   const [message, setMessage] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -35,14 +39,14 @@ const App = () => {
         </Typography>
 
         <Button variant="contained" color="primary" onClick={selectFolder} disabled={isLoading}>
-          フォルダを選択
+          { t('Select-Folder') }
         </Button>
 
         <Box my={2}>
           <TextField
             fullWidth
             variant="outlined"
-            label="フォルダパス"
+            label={ t('Folder-Path') }
             value={folderPath}
             InputProps={{
               readOnly: true,
@@ -52,7 +56,9 @@ const App = () => {
 
         <Box my={2}>
           <FormControl>
-            <FormLabel component="legend">変換タイプを選択</FormLabel>
+            <FormLabel component="legend">
+              { t('Select-Type') }
+            </FormLabel>
             <RadioGroup
               row
               value={conversionType}
@@ -67,7 +73,9 @@ const App = () => {
 
         <Box my={2}>
           <FormControl>
-            <FormLabel component="legend" mt={4}>元のファイルを削除</FormLabel>
+            <FormLabel component="legend" mt={4}>
+              { t('Delete-Original') }
+            </FormLabel>
             <RadioGroup
               row
               value={removeFile}
@@ -82,7 +90,7 @@ const App = () => {
 
 
         <Button variant="contained" color="secondary" onClick={convertFiles} disabled={isLoading}>
-          変換
+          { t('Convert') }
         </Button>
 
         <Box my={2}>

--- a/src/renderer/src/App.jsx
+++ b/src/renderer/src/App.jsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
 import { Button, Typography, TextField, Box, Container, Alert, CircularProgress, Radio, RadioGroup, FormControlLabel, FormLabel, FormControl } from '@mui/material';
 
+import './I18n'
+
+
 const App = () => {
   const [folderPath, setFolderPath] = useState('');
   const [message, setMessage] = useState('');

--- a/src/renderer/src/App.jsx
+++ b/src/renderer/src/App.jsx
@@ -5,30 +5,33 @@ import { useTranslation } from 'react-i18next'
 import './I18n'
 
 
+const { electron } = window
+
+
 const App = () => {
 
   const { i18n , t } = useTranslation('Conversion')
 
-  const [folderPath, setFolderPath] = useState('');
+  const [folderPath, setFolderPath] = useState(null);
   const [message, setMessage] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [conversionType, setConversionType] = useState('webp-to-png');  // 変換タイプの状態管理
   const [removeFile, setRemoveFile] = useState("false")
 
   const selectFolder = async () => {
-    const folder = await window.electron.selectFolder();  // preload経由でIPC通信
-    setFolderPath(folder || 'フォルダが選択されていません');
+    const folder = await electron.selectFolder();  // preload経由でIPC通信
+    setFolderPath( folder ?? null );
   };
 
   const convertFiles = async () => {
-    if (folderPath && folderPath !== 'フォルダが選択されていません') {
-      setIsLoading(true)
-      const result = await window.electron.convertWebPToPNG(folderPath, conversionType, removeFile);  // IPC通信
-      setIsLoading(false)
-      setMessage(result);
-    } else {
-      setMessage('フォルダを選択してください');
-    }
+
+    if( ! folderPath )
+      return
+
+    setIsLoading(true)
+    const result = await window.electron.convertWebPToPNG(folderPath, conversionType, removeFile);  // IPC通信
+    setIsLoading(false)
+    setMessage(result);
   };
 
   return (
@@ -59,10 +62,10 @@ const App = () => {
             fullWidth
             variant="outlined"
             label={ t('Folder-Path') }
-            value={folderPath}
-            InputProps={{
-              readOnly: true,
-            }}
+            value={folderPath ?? 'フォルダが選択されていません' }
+            aria-readonly = 'true'
+            aria-disabled = 'true'
+            disabled = { true }
           />
         </Box>
 
@@ -101,7 +104,12 @@ const App = () => {
         </Box>
 
 
-        <Button variant="contained" color="secondary" onClick={convertFiles} disabled={isLoading}>
+        <Button
+          variant="contained"
+          color="secondary"
+          onClick={convertFiles}
+          disabled={isLoading || ! folderPath }
+        >
           { t('Convert') }
         </Button>
 

--- a/src/renderer/src/App.jsx
+++ b/src/renderer/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, Typography, TextField, Box, Container, Alert, CircularProgress, Radio, RadioGroup, FormControlLabel, FormLabel, FormControl } from '@mui/material';
+import { Button, Typography, TextField, Box, Container, Alert, CircularProgress, Radio, RadioGroup, FormControlLabel, FormLabel, FormControl, Select , MenuItem } from '@mui/material';
 import { useTranslation } from 'react-i18next'
 
 import './I18n'
@@ -7,7 +7,7 @@ import './I18n'
 
 const App = () => {
 
-  const { t } = useTranslation('Conversion')
+  const { i18n , t } = useTranslation('Conversion')
 
   const [folderPath, setFolderPath] = useState('');
   const [message, setMessage] = useState('');
@@ -33,6 +33,18 @@ const App = () => {
 
   return (
     <Container maxWidth="sm">
+      <Select
+        value = { i18n.language }
+        onChange = { ( event ) => {
+
+          const language = event.target.value
+
+          i18n.changeLanguage(language)
+        }}
+      >
+        <MenuItem value={'jp'}>JP</MenuItem>
+        <MenuItem value={'en'}>EN</MenuItem>
+      </Select>
       <Box my={4} textAlign="center">
         <Typography variant="h4" gutterBottom>
           WebP - PNG Converter

--- a/src/renderer/src/I18n.ts
+++ b/src/renderer/src/I18n.ts
@@ -3,10 +3,12 @@ import { initReactI18next } from 'react-i18next'
 import * as en from '../Locales/en.json'
 import * as jp from '../Locales/jp.json'
 
-import i18n from 'i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
+import I18n from 'i18next'
 
 
-i18n
+I18n
+.use(LanguageDetector)
 .use(initReactI18next)
 .init({
 
@@ -14,7 +16,6 @@ i18n
 
   fallbackLng : 'en' ,
   defaultNS : 'common' ,
-  lng : 'jp',
 
   interpolation : {
     escapeValue : false
@@ -22,4 +23,4 @@ i18n
 })
 
 
-export default i18n
+export default I18n

--- a/src/renderer/src/I18n.ts
+++ b/src/renderer/src/I18n.ts
@@ -11,6 +11,9 @@ i18n
 .init({
 
   resources : { en, jp } ,
+
+  fallbackLng : 'en' ,
+  defaultNS : 'common' ,
   lng : 'jp',
 
   interpolation : {

--- a/src/renderer/src/I18n.ts
+++ b/src/renderer/src/I18n.ts
@@ -12,7 +12,7 @@ I18n
 .use(initReactI18next)
 .init({
 
-  resources : { en, jp } ,
+  resources : { en , jp } ,
 
   fallbackLng : 'en' ,
   defaultNS : 'common' ,

--- a/src/renderer/src/I18n.ts
+++ b/src/renderer/src/I18n.ts
@@ -1,0 +1,22 @@
+import { initReactI18next } from 'react-i18next'
+
+import * as en from '../Locales/en.json'
+import * as jp from '../Locales/jp.json'
+
+import i18n from 'i18next'
+
+
+i18n
+.use(initReactI18next)
+.init({
+
+  resources : { en, jp } ,
+  lng : 'jp',
+
+  interpolation : {
+    escapeValue : false
+  }
+})
+
+
+export default i18n

--- a/src/renderer/src/main.jsx
+++ b/src/renderer/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
Integrated reactI18next to translate frontend strings.

-> Backend messages should be converted into  
Ids to be able to translate them in the frontend

- Added basic language selector for switching
- Default language should be detected automatically
- Improved folder path logic + convert button disabling

![image](https://github.com/user-attachments/assets/e14e52c6-960d-4ed4-949e-a3a9dd6ec00b)
![image](https://github.com/user-attachments/assets/6fcc02b1-e814-4051-9724-92adce623da0)
